### PR TITLE
Fix for issue #1.

### DIFF
--- a/ParforProgressbar.m
+++ b/ParforProgressbar.m
@@ -272,9 +272,9 @@ function draw_progress_bar(~, ~, o)
         EstWorkPerWorker = o.totalIterations / numWorkers;
         progWorker = double(o.workerTable.progress) / EstWorkPerWorker;
         progWorkerC = mat2cell(progWorker,ones(1,length(progWorker)));
-        progressbar(progressTotal, progWorkerC{:});
+        progressbar(min(1,progressTotal + eps(progressTotal)), progWorkerC{:});
     else
-        progressbar(progressTotal);
+        progressbar(min(1,progressTotal + eps(progressTotal)));
     end
 end
 


### PR DESCRIPTION
This addresses [issue #1](https://github.com/fsaxen/ParforProgMon/issues/1)  which causes the internal `progressbar` to be restarted and clear the labels. 

The problem was that for fairly long iterations, if no progress was made within the defined update period, the internall `progressbar` would be called with all-zero inputs, which would reset, among else, it removing labels.

The introduced change was to add a small epsilon to stop the progressbar from getting cleared.

TODO: before the first iteration is completed, the estimated time is "Inf week", this should be made more meaningful like "Waiting", "Waiting for the first iteration to complete", "Estimating ETA..." or something similar.